### PR TITLE
Clubs page

### DIFF
--- a/src/app/clubs/events/page.tsx
+++ b/src/app/clubs/events/page.tsx
@@ -1,0 +1,3 @@
+export default async function ClubEventPage(){
+  return <div className="p-3">Find an event!</div>
+} 

--- a/src/app/clubs/join/[slug]/page.tsx
+++ b/src/app/clubs/join/[slug]/page.tsx
@@ -1,0 +1,66 @@
+import { clubs } from "@/app/utils/clubs";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+interface Props {
+  params: { slug: string };
+}
+
+export default async function ClubPage({ params }: Props) {
+  const club = clubs.find((club) => club.slug === params.slug);
+  if (!club) return notFound();
+
+  return (
+    <>
+      <Link href="/clubs/join">{"<-"}</Link>
+      <h1 className="mt-3 font-black text-3xl">{club.name}</h1>
+
+      <div className="mt-5 border rounded-md p-5">
+        <h2 className="font-medium text-lg mb-1">Contact information</h2>
+        <div className="space-y-2">
+          <div>
+            {club.website && (
+              <a href={club.website} className="underline">
+                {club.website}
+              </a>
+            )}
+          </div>
+          <div>
+            {club.president && <Contact title="President" name={club.president.name} email={club.president.email} />}
+            {club.contact && <Contact title="Contact" name={club.contact.name} email={club.contact.email} />}
+          </div>
+        </div>
+      </div>
+
+      <article className="mt-5 space-y-3">
+        <p>
+          Some more information about the club can come here. This is just some placeholder text, but it should be
+          replaced with some information on what the club does. The information can come from Notion.
+        </p>
+
+        <ul className="list-inside list-disc ml-4">
+          <li>Here is a list</li>
+          <li>Just for demonstration purposes</li>
+        </ul>
+      </article>
+    </>
+  );
+}
+
+function Contact({ title, name, email }: { title: string; name: string; email?: string }) {
+  return (
+    <div>
+      <span className="text-gray-500">{title}:</span> {name}
+      {email && (
+        <span className="text-gray-500">
+          {" "}
+          (
+          <a href={email} className="underline">
+            email
+          </a>
+          )
+        </span>
+      )}
+    </div>
+  );
+}

--- a/src/app/clubs/join/layout.tsx
+++ b/src/app/clubs/join/layout.tsx
@@ -1,0 +1,5 @@
+import { ReactNode } from "react";
+
+export default async function JoinClubsLayout({ children }: { children: ReactNode }) {
+  return <div className="p-3 md:py-5 md:mx-auto md:max-w-[75ch]">{children}</div>;
+}

--- a/src/app/clubs/join/page.tsx
+++ b/src/app/clubs/join/page.tsx
@@ -1,0 +1,64 @@
+export default async function JoinClubsPage() {
+  // TODO: get actual list of clubs from Notion
+  const clubs = [
+    {
+      name: "Code4Community",
+      email: "c4cneu@gmail.com",
+      website: "https://www.c4cneu.com/",
+      president: {
+        name: "Somya Prabhakar",
+        email: "prabhakar.so@northeastern.edu",
+      },
+      contact: {
+        name: "Somya Prabhakar",
+        email: "prabhakar.so@northeastern.edu",
+      },
+    },
+    {
+      name: "ColorStack",
+      president: {
+        name: "Levin Sanchez",
+        email: "sanchez.le@northeastern.edu",
+      },
+    },
+    {
+      name: "NER",
+      email: "northeasternelectricracing@gmail.com",
+      website: "https://electricracing.northeastern.edu",
+      president: {
+        name: "Catherine Kennedy",
+      },
+      contact: {
+        name: "Anthony Bernardi",
+        email: "bernardi.an@northeastern.edu",
+      },
+    },
+    {
+      name: "Sandbox",
+      email: "sandboxneu@gmail.com",
+      website: "https://www.sandboxnu.com/",
+      president: {
+        name: "Ally Chao",
+        email: "chao.al@northeastern.edu",
+      },
+      contact: {
+        name: "Ally Chao",
+        email: "chao.al@northeastern.edu",
+      },
+    },
+  ];
+
+  return (
+    <div className="p-3 md:py-5 md:mx-auto md:max-w-[75ch]">
+      <h1 className="font-black text-3xl">Khoury Clubs</h1>
+
+      <div className="mt-5 space-y-3">
+        {clubs.map(club => {
+          return <section className="border rounded-md p-5">
+            <div className="font-medium text-lg">{club.name}</div>
+          </section>
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/app/clubs/join/page.tsx
+++ b/src/app/clubs/join/page.tsx
@@ -1,64 +1,27 @@
+import { clubs } from "@/app/utils/clubs";
+import Link from "next/link";
+
 export default async function JoinClubsPage() {
   // TODO: get actual list of clubs from Notion
-  const clubs = [
-    {
-      name: "Code4Community",
-      email: "c4cneu@gmail.com",
-      website: "https://www.c4cneu.com/",
-      president: {
-        name: "Somya Prabhakar",
-        email: "prabhakar.so@northeastern.edu",
-      },
-      contact: {
-        name: "Somya Prabhakar",
-        email: "prabhakar.so@northeastern.edu",
-      },
-    },
-    {
-      name: "ColorStack",
-      president: {
-        name: "Levin Sanchez",
-        email: "sanchez.le@northeastern.edu",
-      },
-    },
-    {
-      name: "NER",
-      email: "northeasternelectricracing@gmail.com",
-      website: "https://electricracing.northeastern.edu",
-      president: {
-        name: "Catherine Kennedy",
-      },
-      contact: {
-        name: "Anthony Bernardi",
-        email: "bernardi.an@northeastern.edu",
-      },
-    },
-    {
-      name: "Sandbox",
-      email: "sandboxneu@gmail.com",
-      website: "https://www.sandboxnu.com/",
-      president: {
-        name: "Ally Chao",
-        email: "chao.al@northeastern.edu",
-      },
-      contact: {
-        name: "Ally Chao",
-        email: "chao.al@northeastern.edu",
-      },
-    },
-  ];
 
   return (
-    <div className="p-3 md:py-5 md:mx-auto md:max-w-[75ch]">
+    <>
       <h1 className="font-black text-3xl">Khoury Clubs</h1>
 
       <div className="mt-5 space-y-3">
-        {clubs.map(club => {
-          return <section className="border rounded-md p-5">
-            <div className="font-medium text-lg">{club.name}</div>
-          </section>
+        {clubs.map((club) => {
+          return (
+            <Link
+              key={club.slug}
+              href={`/clubs/join/${club.slug}`}
+              className="border rounded-md p-5 flex items-center justify-between"
+            >
+              <div className="font-medium text-lg">{club.name}</div>
+              <div>{"->"}</div>
+            </Link>
+          );
         })}
       </div>
-    </div>
+    </>
   );
 }

--- a/src/app/clubs/layout.tsx
+++ b/src/app/clubs/layout.tsx
@@ -1,0 +1,21 @@
+import { ReactNode } from "react";
+import Navbar from "../navbar";
+import Link from "next/link";
+import { strings } from "../utils/strings";
+import SidebarButton from "./sidebar-button";
+
+export default async function ClubsLayout({ children }: { children: ReactNode }) {
+  return (
+    <main className="md:[--sidebar-length:250px]">
+      <Navbar />
+      <div className="flex">
+        <aside className="w-[--sidebar-length] p-3 space-y-1">
+          {strings.home.links.map((link) => {
+            return <SidebarButton href={link.destination}>{link.title}</SidebarButton>;
+          })}
+        </aside>
+        <div className="flex-1">{children}</div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/clubs/page.tsx
+++ b/src/app/clubs/page.tsx
@@ -1,0 +1,3 @@
+export default async function ClubsPage() {
+  return <></>;
+}

--- a/src/app/clubs/sidebar-button.tsx
+++ b/src/app/clubs/sidebar-button.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { ReactNode } from "react";
+
+export default function SidebarButton({ href, children }: { href: string; children: ReactNode }) {
+  const pathname = usePathname();
+  const isActive = pathname.startsWith(href);
+  return (
+    <Link
+      href={href}
+      className={`block font-medium px-2 py-1 hover:bg-gray-100 rounded-md ${isActive && "bg-gray-200"}`}
+    >
+      {children}
+    </Link>
+  );
+}

--- a/src/app/navbar.tsx
+++ b/src/app/navbar.tsx
@@ -1,0 +1,13 @@
+import Link from "next/link";
+import { strings } from "./utils/strings";
+
+export default function Navbar() {
+  return (
+    <header className="p-3 border-b">
+      <Link href="/" className="flex items-center space-x-2">
+        <img src="/kaleidoscope-640.png" alt="kaleidoscope logo" className="w-7 h-7 drop-shadow-md" />
+        <div className="font-bold text-lg text-khoury-blue">{strings.home.club_name}</div>
+      </Link>
+    </header>
+  );
+}

--- a/src/app/utils/clubs.ts
+++ b/src/app/utils/clubs.ts
@@ -1,0 +1,53 @@
+// TODO: get actual list of clubs from Notion
+// Remove this when no longer needed
+export const clubs = [
+  {
+    slug: "code4community",
+    name: "Code4Community",
+    email: "c4cneu@gmail.com",
+    website: "https://www.c4cneu.com/",
+    president: {
+      name: "Somya Prabhakar",
+      email: "prabhakar.so@northeastern.edu",
+    },
+    contact: {
+      name: "Somya Prabhakar",
+      email: "prabhakar.so@northeastern.edu",
+    },
+  },
+  {
+    slug: "colorstack",
+    name: "ColorStack",
+    president: {
+      name: "Levin Sanchez",
+      email: "sanchez.le@northeastern.edu",
+    },
+  },
+  {
+    slug: "ner",
+    name: "NER",
+    email: "northeasternelectricracing@gmail.com",
+    website: "https://electricracing.northeastern.edu",
+    president: {
+      name: "Catherine Kennedy",
+    },
+    contact: {
+      name: "Anthony Bernardi",
+      email: "bernardi.an@northeastern.edu",
+    },
+  },
+  {
+    slug: "sandbox",
+    name: "Sandbox",
+    email: "sandboxneu@gmail.com",
+    website: "https://www.sandboxnu.com/",
+    president: {
+      name: "Ally Chao",
+      email: "chao.al@northeastern.edu",
+    },
+    contact: {
+      name: "Ally Chao",
+      email: "chao.al@northeastern.edu",
+    },
+  },
+];

--- a/src/app/utils/strings.ts
+++ b/src/app/utils/strings.ts
@@ -5,15 +5,15 @@ export const strings = {
       links: [
          {
             title: "Join a club",
-            destination: ""
+            destination: "/clubs/join"
          },
          {
             title: "Find an event",
-            destination: ""
+            destination: "/clubs/events"
          },
          {
             title: "Manage my org",
-            destination: ""
+            destination: "/clubs/manage"
          },
       ]
    }


### PR DESCRIPTION
Added the `/clubs/` page with an Events page (will show club events from Notion's calendar):

<img width="1512" alt="image" src="https://github.com/fraander/kaleidoscope/assets/34677361/dbc7fd06-e172-4769-81a6-6cfeddc2c169">

Join a club page:

This page lists out all clubs

<img width="1512" alt="image" src="https://github.com/fraander/kaleidoscope/assets/34677361/e253bd46-eeda-4311-b6a4-dfa05b9a7673">

Clicking on a club shows more information:

<img width="1512" alt="image" src="https://github.com/fraander/kaleidoscope/assets/34677361/18b28fae-cd88-4506-8344-9aee75877506">

## Todo:

- [ ] Get club information from Notion instead of hardcoding (either use contentlayer or Notion API)
- [ ] Khoury dots background
- [ ] Mobile support